### PR TITLE
Add error checking for Console Commands

### DIFF
--- a/Connect.DNN.Powershell/Common/Extensions.cs
+++ b/Connect.DNN.Powershell/Common/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Connect.DNN.Powershell.Framework.Models;
+using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -48,6 +49,14 @@ namespace Connect.DNN.Powershell.Common
                 }
             }
             return result;
+        }
+
+        public static void AssertValidConsoleResponse<T>(this ConsoleResultModel<T> result)
+        {
+            if (result.IsError)
+            {
+                throw new InvalidOperationException(result.Output);
+            }
         }
     }
 }

--- a/Connect.DNN.Powershell/Core/Commands/CommandCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/CommandCommands.cs
@@ -1,4 +1,5 @@
-﻿using Connect.DNN.Powershell.Core.Models;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Core.Models;
 using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
 
@@ -10,6 +11,7 @@ namespace Connect.DNN.Powershell.Core.Commands
         {
             var response = DnnPromptController.ProcessCommand(site, 5, "list-commands");
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<Command>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
     }

--- a/Connect.DNN.Powershell/Core/Commands/HostCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/HostCommands.cs
@@ -1,4 +1,5 @@
-﻿using Connect.DNN.Powershell.Core.Models;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Core.Models;
 using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
 
@@ -15,6 +16,7 @@ namespace Connect.DNN.Powershell.Core.Commands
         {
             var response = DnnPromptController.ProcessCommand(site, 5, "get-host");
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<HostModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
     }

--- a/Connect.DNN.Powershell/Core/Commands/ModuleCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/ModuleCommands.cs
@@ -1,4 +1,5 @@
-﻿using Connect.DNN.Powershell.Core.Models;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Core.Models;
 using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
 
@@ -13,6 +14,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += string.IsNullOrEmpty(moduleTitle) ? "" : string.Format(" --title {0}", moduleTitle);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<ModuleInstanceModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
         public static ModuleInfoModel CopyModule(Data.Site site, int portalId, int moduleId, int pageId, int toPageId, string paneName, bool? includeSettings)
@@ -22,6 +24,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += includeSettings == null ? "" : string.Format(" --includesettings {0}", includeSettings);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<ModuleInfoModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static string DeleteModule(Data.Site site, int portalId, int moduleId, int pageId)
@@ -29,6 +32,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = string.Format("copy-module --id {0} --pageid {1}", moduleId, pageId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static ModuleInfoModel GetModule(Data.Site site, int portalId, int moduleId, int pageId)
@@ -36,6 +40,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = string.Format("get-module --id {0} --pageid {1}", moduleId, pageId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<ModuleInfoModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static ModuleInfoModel[] ListModules(Data.Site site, int portalId, string moduleName, string moduleTitle, int? pageId, bool? deleted, int? page, int? max)
@@ -49,6 +54,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += max == null ? "" : string.Format(" --max {0}", max);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<ModuleInfoModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
         public static ModuleInfoModel MoveModule(Data.Site site, int portalId, int moduleId, int pageId, int toPageId, string paneName)
@@ -57,6 +63,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += string.IsNullOrEmpty(paneName) ? "" : string.Format(" --pane {0}", paneName);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<ModuleInfoModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
 

--- a/Connect.DNN.Powershell/Core/Commands/PageCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/PageCommands.cs
@@ -1,4 +1,5 @@
-﻿using Connect.DNN.Powershell.Core.Models;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Core.Models;
 using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
 
@@ -14,6 +15,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += parentId == null ? "" : string.Format(" --parentid {0}", parentId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static PageModel GetPage(Data.Site site, int portalId, int? pageId, string pageName, int? parentId)
@@ -24,6 +26,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += parentId == null ? "" : string.Format(" --parentid {0}", parentId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<PageModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static string GetPageUrl(Data.Site site, int portalId, int? pageId, string pageName, int? parentId)
@@ -34,6 +37,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += parentId == null ? "" : string.Format(" --parentid {0}", parentId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static PageModelBase[] ListPages(Data.Site site, int portalId, int? parentId, bool? deleted, string pageName, string pageTitle, string path, string skin, bool? visible, int? page, int? max)
@@ -50,6 +54,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += max == null ? "" : string.Format(" --max {0}", max);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<PageModelBase>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
         public static PageModel NewPage(Data.Site site, int portalId, int? parentId, string pageTitle, string pageName, string url, string description, string keywords, bool? visible)
@@ -63,6 +68,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += visible == null ? "" : string.Format(" --visible {0}", visible);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<PageModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static PageModel SetPage(Data.Site site, int portalId, int pageId, int? parentId, string pageTitle, string pageName, string url, string description, string keywords, bool? visible)
@@ -76,6 +82,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += visible == null ? "" : string.Format(" --visible {0}", visible);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<PageModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
     }

--- a/Connect.DNN.Powershell/Core/Commands/PortalCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/PortalCommands.cs
@@ -1,4 +1,5 @@
-﻿using Connect.DNN.Powershell.Core.Models;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Core.Models;
 using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
 
@@ -15,12 +16,14 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = portalId == -1 ? "get-portal" : string.Format("get-portal --id {0}", portalId);
             var response = DnnPromptController.ProcessCommand(site, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<Portal>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static PortalBase[] ListPortals(Data.Site site)
         {
             var response = DnnPromptController.ProcessCommand(site, 5, "list-portals");
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<PortalBase>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
         public static Portal ClearLog(Data.Site site)
@@ -31,6 +34,7 @@ namespace Connect.DNN.Powershell.Core.Commands
         {
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, "get-portal");
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<Portal>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
     }

--- a/Connect.DNN.Powershell/Core/Commands/RecyclebinCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/RecyclebinCommands.cs
@@ -1,4 +1,5 @@
-﻿using Connect.DNN.Powershell.Framework;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
 
 namespace Connect.DNN.Powershell.Core.Commands
@@ -10,6 +11,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = string.Format("purge-module --id {0} --pageid {1}", moduleId, pageId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static string PurgePage(Data.Site site, int portalId, int pageId, bool? deleteChildren)
@@ -18,6 +20,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += deleteChildren == null ? "" : string.Format(" --deletechildren {0}", deleteChildren);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static string PurgeUser(Data.Site site, int portalId, int userId)
@@ -25,6 +28,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = string.Format("purge-user --id {0}", userId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static string RestoreModule(Data.Site site, int portalId, int moduleId, int pageId)
@@ -32,6 +36,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = string.Format("restore-module --id {0} --pageid {1}", moduleId, pageId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static string RestorePage(Data.Site site, int portalId, int? pageId, string pageName, int? parentId)
@@ -42,6 +47,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += parentId == null ? "" : string.Format(" --parentid {0}", parentId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static string RestoreUser(Data.Site site, int portalId, int userId)
@@ -49,6 +55,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = string.Format("restore-user --id {0}", userId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
     }

--- a/Connect.DNN.Powershell/Core/Commands/RoleCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/RoleCommands.cs
@@ -1,4 +1,5 @@
-﻿using Connect.DNN.Powershell.Core.Models;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Core.Models;
 using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
 
@@ -10,18 +11,21 @@ namespace Connect.DNN.Powershell.Core.Commands
         {
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, string.Format("delete-role --id {0}", roleId));
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static RoleModel GetRole(Data.Site site, int portalId, int roleId)
         {
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, string.Format("get-role --id {0}", roleId));
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<RoleModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static RoleModelBase[] ListRoles(Data.Site site, int portalId)
         {
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, "list-roles");
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<RoleModelBase>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
         public static RoleModel NewRole(Data.Site site, int portalId, string roleName, string description, bool? isPublic, bool? autoAssign, RoleStatus? status)
@@ -33,6 +37,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += status == null ? "" : string.Format(" --status {0}", status.ToString());
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<RoleModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static RoleModel SetRole(Data.Site site, int portalId, int roleId, string roleName, string description, bool? isPublic, bool? autoAssign, RoleStatus? status)
@@ -45,6 +50,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += status == null ? "" : string.Format(" --status {0}", status.ToString());
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<RoleModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
 

--- a/Connect.DNN.Powershell/Core/Commands/TaskSchedulerCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/TaskSchedulerCommands.cs
@@ -1,4 +1,5 @@
-﻿using Connect.DNN.Powershell.Core.Models;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Core.Models;
 using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
 
@@ -11,6 +12,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = string.Format("get-task --id {0}", taskId);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<TaskModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static TaskModelBase[] ListTasks(Data.Site site, int portalId, bool? enabled, string taskName)
@@ -20,6 +22,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += string.IsNullOrEmpty(taskName) ? "" : string.Format(" --name {0}", taskName);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<TaskModelBase>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
         public static TaskModel SetTask(Data.Site site, int portalId, int taskId, bool enabled)
@@ -27,6 +30,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             var cmd = string.Format("set-task --id {0} --enabled {1}", taskId, enabled);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<TaskModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
     }

--- a/Connect.DNN.Powershell/Core/Commands/UserCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/UserCommands.cs
@@ -1,6 +1,8 @@
-﻿using Connect.DNN.Powershell.Core.Models;
+﻿using Connect.DNN.Powershell.Common;
+using Connect.DNN.Powershell.Core.Models;
 using Connect.DNN.Powershell.Framework;
 using Connect.DNN.Powershell.Framework.Models;
+using System;
 
 namespace Connect.DNN.Powershell.Core.Commands
 {
@@ -13,6 +15,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += end == null ? "" : string.Format(" --start {0:yyyy-MM-dd}", end);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<UserRoleModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
         public static UserModel DeleteUser(Data.Site site, int portalId, int userId, bool? notify)
@@ -21,6 +24,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += notify == null ? "" : string.Format(" --notify {0}", notify);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<UserModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static UserModel GetUser(Data.Site site, int portalId, int? userId, string email, string username)
@@ -31,6 +35,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += string.IsNullOrEmpty(username) ? "" : string.Format(" --username {0}", username);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<UserModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static UserModelBase[] ListUsers(Data.Site site, int portalId, string email, string username, string role, int? page, int? max)
@@ -43,6 +48,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += max == null ? "" : string.Format(" --max {0}", max);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<UserModelBase>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data;
         }
         public static UserModel NewUser(Data.Site site, int portalId, string email, string username, string firstname, string lastname, string password, bool? approved, bool? notify)
@@ -53,6 +59,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += notify == null ? "" : string.Format(" --notify {0}", notify);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<UserModel>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Data[0];
         }
         public static string ResetPassword(Data.Site site, int portalId, int userId, bool? notify)
@@ -61,10 +68,11 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += notify == null ? "" : string.Format(" --notify {0}", notify);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<object>>(response.Contents);
+            result.AssertValidConsoleResponse();
             return result.Output;
         }
         public static UserModel SetUser(Data.Site site, int portalId, int userId, string email, string username, string displayname, string firstname, string lastname, string password, bool? approved)
-        {
+        { 
             var cmd = string.Format("set-user --id {0}", userId);
             cmd += string.IsNullOrEmpty(email) ? "" : string.Format(" --email {0}", email);
             cmd += string.IsNullOrEmpty(username) ? "" : string.Format(" --username {0}", username);
@@ -75,7 +83,8 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += approved == null ? "" : string.Format(" --approved {0}", approved);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<UserModel>>(response.Contents);
-            return result.Data[0];
+            result.AssertValidConsoleResponse();
+            return result?.Data[0];
         }
     }
 }


### PR DESCRIPTION
Fix Issue #5
This is a pattern that is broken for every command and needs to be addressed everywhere that a result is returned from the console.