### PR TITLE
Fixed bug when trying to get a user by username

### DIFF
--- a/Connect.DNN.Powershell/Core/Commands/UserCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/UserCommands.cs
@@ -30,7 +30,7 @@ namespace Connect.DNN.Powershell.Core.Commands
         public static UserModel GetUser(Data.Site site, int portalId, int? userId, string email, string username)
         {
             var cmd = string.Format("get-user");
-            cmd += userId == null ? "" : string.Format(" --id {0}", userId);
+            cmd += userId == 0 ? "" : string.Format(" --id {0}", userId);
             cmd += string.IsNullOrEmpty(email) ? "" : string.Format(" --email {0}", email);
             cmd += string.IsNullOrEmpty(username) ? "" : string.Format(" --username {0}", username);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);


### PR DESCRIPTION
I changed a logic check in the `GetUser()` command.

The request for getting a user by username would fail because DNN-Powershell would add `--id 0` even if no id was provided. This was because an int can't be null and would default to 0. As a result, the null check would always be false and add `--id 0` to the request. DNN would then default to try and look up a user by userId and not by username, and since the userId would be 0, the request would fail. 