### PR TITLE
Fixed issue #8

### DIFF
--- a/Connect.DNN.Powershell/Core/Commands/RoleCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/RoleCommands.cs
@@ -34,7 +34,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += string.IsNullOrEmpty(description) ? "" : string.Format(" --description {0}", description);
             cmd += isPublic == null ? "" : string.Format(" --public {0}", isPublic);
             cmd += autoAssign == null ? "" : string.Format(" --autoassign {0}", autoAssign);
-            cmd += status == null ? "" : string.Format(" --status {0}", status.ToString());
+            cmd += status == null ? "" : string.Format(" --status {0}", status.ToString().ToLower());
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<RoleModel>>(response.Contents);
             result.AssertValidConsoleResponse();
@@ -47,7 +47,7 @@ namespace Connect.DNN.Powershell.Core.Commands
             cmd += string.IsNullOrEmpty(description) ? "" : string.Format(" --description {0}", description);
             cmd += isPublic == null ? "" : string.Format(" --public {0}", isPublic);
             cmd += autoAssign == null ? "" : string.Format(" --autoassign {0}", autoAssign);
-            cmd += status == null ? "" : string.Format(" --status {0}", status.ToString());
+            cmd += status == null ? "" : string.Format(" --status {0}", status.ToString().ToLower());
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);
             var result = Newtonsoft.Json.JsonConvert.DeserializeObject<ConsoleResultModel<RoleModel>>(response.Contents);
             result.AssertValidConsoleResponse();


### PR DESCRIPTION
Creating and assigning roles would fail because the status enum would send a capitolized string to DNN, but since DNN expects a lower-cased string, the request would fail. This was the cause of issue #8.