### PR TITLE
Fixed bug when a role name or description has a space

### DIFF
--- a/Connect.DNN.Powershell/Core/Commands/RoleCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/RoleCommands.cs
@@ -30,8 +30,8 @@ namespace Connect.DNN.Powershell.Core.Commands
         }
         public static RoleModel NewRole(Data.Site site, int portalId, string roleName, string description, bool? isPublic, bool? autoAssign, RoleStatus? status)
         {
-            var cmd = string.Format("new-role --name {0}", roleName);
-            cmd += string.IsNullOrEmpty(description) ? "" : string.Format(" --description {0}", description);
+            var cmd = string.Format("new-role --name \"{0}\"", roleName);
+            cmd += string.IsNullOrEmpty(description) ? "" : string.Format(" --description \"{0}\"", description);
             cmd += isPublic == null ? "" : string.Format(" --public {0}", isPublic);
             cmd += autoAssign == null ? "" : string.Format(" --autoassign {0}", autoAssign);
             cmd += status == null ? "" : string.Format(" --status {0}", status.ToString());

--- a/Connect.DNN.Powershell/Core/Commands/UserCommands.cs
+++ b/Connect.DNN.Powershell/Core/Commands/UserCommands.cs
@@ -10,7 +10,7 @@ namespace Connect.DNN.Powershell.Core.Commands
     {
         public static UserRoleModel[] AddRoles(Data.Site site, int portalId, int userId, string roles, System.DateTime? start, System.DateTime? end)
         {
-            var cmd = string.Format("add-roles --id {0} --roles {1}", userId, roles);
+            var cmd = string.Format("add-roles --id {0} --roles \"{1}\"", userId, roles);
             cmd += start == null ? "" : string.Format(" --start {0:yyyy-MM-dd}", start);
             cmd += end == null ? "" : string.Format(" --start {0:yyyy-MM-dd}", end);
             var response = DnnPromptController.ProcessCommand(site, portalId, 5, cmd);


### PR DESCRIPTION
You can now successfully create and assign roles that have spaces in their names or descriptions.

By adding quotation marks around the string, the input string will be treated as one argument and the spaces will be included. This change also fixes the issue of trying to assign multiple roles at one time, you just need to have them comma separated and DNN will take care of the rest.